### PR TITLE
fix: protect .Trash and sensitive dotfiles in $HOME

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,21 @@ A broad `(deny file* (subpath HOME))` also breaks `kqueue`/FSEvents and SQLite `
 
 The solution is a **blocklist**: individually deny only the directories that should be protected, leaving everything else at the default `(allow default)`.
 
+### Allow-first vs. deny-first: a deliberate trade-off
+
+Some sandbox tools (e.g. [agent-safehouse](https://github.com/eugene1g/agent-safehouse)) start from `(deny default)` and explicitly allow every path the app needs. This **deny-first / allowlist** model has one advantage: you can deny a parent directory and still allow a specific child, because a specific `allow` wins over the catch-all `deny default`.
+
+bx-mac uses the opposite **allow-first / blocklist** model, for a deliberate reason: developer tools require access to an enormous and ever-changing set of paths (dotfiles, `~/Library`, runtimes, caches). With deny-first, every new tool or framework would require new allow rules - fragile, hard to maintain, and likely to break silently. With allow-first, things work out of the box; only sensitive paths are explicitly denied.
+
+The practical difference for `~/Library`:
+
+| Model | ~/Library | Specific subdir |
+| --- | --- | --- |
+| deny-first | blocked by default | can be selectively opened |
+| allow-first (bx-mac) | open by default | sensitive subdirs individually blocked |
+
+Neither model fully "wins" - deny-first is theoretically stricter but requires significant configuration effort and breaks more easily. bx-mac's blocklist model is the right choice for a tool that needs to work without per-tool tuning.
+
 ### How the profile is generated
 
 1. Parse `~/.bxignore` for `rw:` (read-write) and `ro:` (read-only) entries

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,9 @@ secrets/          # blocks secrets/ directories at any depth
 
 These are always blocked, regardless of configuration:
 
-**Dotdirs:** `.ssh`, `.gnupg`, `.docker`, `.zsh_sessions`, `.cargo`, `.gradle`, `.gem`
+**Dotdirs:** `.Trash`, `.ssh`, `.gnupg`, `.docker`, `.zsh_sessions`, `.cargo`, `.gradle`, `.gem`
+
+**Dotfiles:** `.zsh_history`, `.bash_history`, `.sh_history`, `.node_repl_history`, `.python_history`, `.netrc`, `.git-credentials`, `.npmrc`, `.pypirc`, `.extra`
 
 **Library (opinionated):** `Accounts`, `Calendars`, `Contacts`, `Cookies`, `Finance`, `Mail`, `Messages`, `Mobile Documents`, `Photos`, `Safari`, and others — plus app containers matching password managers and finance apps (1Password, Bitwarden, MoneyMoney)
 
@@ -199,6 +201,7 @@ The solution is a **blocklist**: individually deny only the directories that sho
 | `~/.*/` (dotfiles/dotdirs) | **full** (except protected ones) |
 | `~/Library` | **full** (except opinionated protected subdirs) |
 | Built-in protected dotdirs | **blocked** |
+| Sensitive home dotfiles (history, credentials) | **blocked** |
 | Protected Library subdirs (Mail, Photos, …) | **blocked** |
 | Password manager / finance app containers | **blocked** |
 | Plain paths in `.bxignore` | **blocked** |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,9 +141,11 @@ secrets/          # blocks secrets/ directories at any depth
 
 These are always blocked, regardless of configuration:
 
-**Dotdirs:** `.Trash`, `.ssh`, `.gnupg`, `.docker`, `.zsh_sessions`, `.cargo`, `.gradle`, `.gem`
+**Dotdirs:** `.Trash`, `.ssh`, `.gnupg`, `.docker`, `.zsh_sessions`, `.cargo`, `.gradle`, `.gem`, `.aws`, `.azure`, `.azd`, `.kube`, `.config/gcloud`
 
-**Dotfiles:** `.zsh_history`, `.bash_history`, `.sh_history`, `.node_repl_history`, `.python_history`, `.netrc`, `.git-credentials`, `.npmrc`, `.pypirc`, `.extra`
+**Dotfiles (fully blocked):** `.zsh_history`, `.bash_history`, `.sh_history`, `.node_repl_history`, `.python_history`, `.netrc`, `.git-credentials`, `.npmrc`, `.pypirc`, `.extra`
+
+**Shell init dotfiles (read-only):** `.zshrc`, `.zprofile`, `.zshenv`, `.zlogin`, `.zlogout`, `.bashrc`, `.bash_profile`, `.bash_login`, `.profile`, `.config/fish/config.fish` - readable but write-protected against injection
 
 **Library (opinionated):** `Accounts`, `Calendars`, `Contacts`, `Cookies`, `Finance`, `Mail`, `Messages`, `Mobile Documents`, `Photos`, `Safari`, and others — plus app containers matching password managers and finance apps (1Password, Bitwarden, MoneyMoney)
 
@@ -202,6 +204,8 @@ The solution is a **blocklist**: individually deny only the directories that sho
 | `~/Library` | **full** (except opinionated protected subdirs) |
 | Built-in protected dotdirs | **blocked** |
 | Sensitive home dotfiles (history, credentials) | **blocked** |
+| Cloud credentials (`.aws`, `.azure`, `.kube`, ...) | **blocked** |
+| Shell init dotfiles (`.zshrc`, `.bashrc`, ...) | **read-only** |
 | Protected Library subdirs (Mail, Photos, …) | **blocked** |
 | Password manager / finance app containers | **blocked** |
 | Plain paths in `.bxignore` | **blocked** |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![license](https://img.shields.io/github/license/holtwick/bx-mac)](https://github.com/holtwick/bx-mac/blob/master/LICENSE)
 [![macOS](https://img.shields.io/badge/platform-macOS-lightgrey)](https://github.com/holtwick/bx-mac)
 
-> **Put your AI in a box.** Launch VSCode, Claude Code, a terminal, or any command in a macOS sandbox — your tools can only see the project you're working on.
+> **Put your AI in a box.** Launch VSCode, Claude Code, a terminal, or any command in a macOS sandbox — your tools can only see the project you're working on. Not a vault, but a reasonable safety net.
 
 ## 🤔 Why?
 
@@ -45,7 +45,23 @@ bx ~/work/my-project ~/work/shared-lib
 - **macOS only** — relies on `sandbox-exec` (Apple-specific)
 - **Not dynamic** — the sandbox profile is a snapshot of `$HOME` at launch time; directories or files created later are **not** automatically blocked
 - **File names visible** — blocked files cannot be read or written, but their names still appear in directory listings (a kernel-level `readdir` constraint, same as `chmod 000`)
-- **Not a vault** — `sandbox-exec` is undocumented; treat this as a safety net, not a guarantee
+- **Not a vault** — this is a safety net, not airtight isolation (see [Security model](#-security-model-allow-first))
+
+## 🧱 Security model: allow-first
+
+bx uses an **allow-first / blocklist** approach: everything is accessible by default, and only sensitive paths are explicitly blocked. This is the opposite of a deny-first / allowlist model where everything is blocked and only specific paths are opened up.
+
+**Why allow-first?** Developer tools require access to an enormous and ever-changing set of paths -- dotfiles, `~/Library`, runtimes, caches, toolchains. A deny-first model would require new allow rules for every tool or framework update, breaking silently when a path is missing. The allow-first model works out of the box without per-tool tuning.
+
+**What this means in practice:**
+
+- bx provides **reasonable protection** against accidental or misguided file access -- not airtight isolation
+- Sensitive paths (credentials, personal data, other projects) are explicitly blocked
+- Paths that are not on the blocklist remain accessible -- including parts of `~/Library` and most dotfiles
+- The sandbox profile is a **snapshot at launch time** -- files created later are not protected
+- `sandbox-exec` itself is undocumented Apple API that could change with OS updates
+
+If you need stricter, deny-first isolation, consider [Agent Safehouse](https://agent-safehouse.dev/) or a Docker/VM-based approach (see [Alternatives](#-alternatives)). bx is designed for the common case: keep AI tools and editors functional while blocking access to things they should never touch.
 
 ## 📥 Install
 

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ These are great when available, but they only protect within their own tool. bx 
 
 ## 🔗 Alternatives
 
-- [Agent Safehouse](https://agent-safehouse.dev/) — macOS kernel-level sandboxing for LLM coding agents via `sandbox-exec`. Deny-first model that blocks write access outside the project directory.
+- [Agent Safehouse](https://agent-safehouse.dev/) — macOS kernel-level sandboxing for LLM coding agents via `sandbox-exec`. Uses a **deny-first model**: everything is blocked by default and only explicitly listed paths are opened up. This gives you theoretically stricter control (e.g. `~/Library` is fully blocked and only specific subdirs are allowed), but requires more configuration — tools and runtimes that need paths you haven't whitelisted will break silently. If you need that level of precision and are willing to tune profiles per tool, Agent Safehouse may be the better fit. bx uses the opposite **allow-first model** (only sensitive paths are blocked), which works out of the box for VSCode, shells, Claude Code, and other tools without any per-tool configuration.
 - **Docker / VMs** — for stronger isolation, run AI tools in a virtualized environment (containers, VMs). Full process and network isolation at the cost of setup overhead.
 - **Web sandboxes** — browser-based approaches for running AI agents. See Simon Willison's [Living dangerously with Claude](https://simonwillison.net/2025/Oct/22/living-dangerously-with-claude/) for an overview.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { createInterface } from "node:readline"
 import process from "node:process"
 import { checkOwnSandbox, checkVSCodeTerminal, checkExternalSandbox, checkWorkDirs, checkAppAlreadyRunning } from "./guards.js"
 import { parseArgs } from "./args.js"
-import { PROTECTED_DOTDIRS, parseHomeConfig, collectBlockedDirs, collectIgnoredPaths, collectSystemDenyPaths, generateProfile } from "./profile.js"
+import { PROTECTED_DOTDIRS, PROTECTED_HOME_DOTFILES, parseHomeConfig, collectBlockedDirs, collectIgnoredPaths, collectReadOnlyDotfiles, collectSystemDenyPaths, generateProfile } from "./profile.js"
 import { setupVSCodeProfile, buildCommand, bringAppToFront, getActivationCommand, getNestedSandboxWarning } from "./modes.js"
 import { loadConfig, getAvailableApps, getValidModes } from "./config.js"
 import { expandGlobs } from "./paths.js"
@@ -104,10 +104,11 @@ async function main() {
   const allAccessible = new Set([...allowed, ...readOnly])
   const blockedDirs = collectBlockedDirs(HOME, HOME, __dirname, allAccessible)
   const ignoredPaths = collectIgnoredPaths(HOME, workDirs)
+  const readOnlyDotfiles = collectReadOnlyDotfiles(HOME)
 
   printPolicySummary(mode, workDirs, blockedDirs, ignoredPaths, readOnly)
 
-  const profile = generateProfile(workDirs, blockedDirs, ignoredPaths, [...readOnly], HOME)
+  const profile = generateProfile(workDirs, blockedDirs, ignoredPaths, [...readOnly], HOME, readOnlyDotfiles)
 
   if (verbose) {
     console.error("\n--- Generated sandbox profile ---")
@@ -237,7 +238,7 @@ function printPolicySummary(
   if (readOnly.size > 0) {
     parts.push(`${readOnly.size} read-only`)
   }
-  const extraIgnored = ignoredPaths.length - PROTECTED_DOTDIRS.length
+  const extraIgnored = ignoredPaths.length - PROTECTED_DOTDIRS.length - PROTECTED_HOME_DOTFILES.length
   if (extraIgnored > 0) {
     parts.push(`${extraIgnored} from .bxignore`)
   }

--- a/src/profile.test.ts
+++ b/src/profile.test.ts
@@ -1,14 +1,25 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest"
 import { mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
-import { collectBlockedDirs, collectIgnoredPaths, generateProfile, isSelfProtected, parseHomeConfig, PROTECTED_DOTDIRS, PROTECTED_LIBRARY_DIRS } from "./profile.js"
+import { collectBlockedDirs, collectIgnoredPaths, generateProfile, isSelfProtected, parseHomeConfig, PROTECTED_DOTDIRS, PROTECTED_HOME_DOTFILES, PROTECTED_LIBRARY_DIRS } from "./profile.js"
 
 describe("PROTECTED_DOTDIRS", () => {
   it("includes essential sensitive directories", () => {
+    expect(PROTECTED_DOTDIRS).toContain(".Trash")
     expect(PROTECTED_DOTDIRS).toContain(".ssh")
     expect(PROTECTED_DOTDIRS).toContain(".gnupg")
     expect(PROTECTED_DOTDIRS).toContain(".docker")
     expect(PROTECTED_DOTDIRS).toContain(".cargo")
+  })
+})
+
+describe("PROTECTED_HOME_DOTFILES", () => {
+  it("includes sensitive dotfiles", () => {
+    expect(PROTECTED_HOME_DOTFILES).toContain(".zsh_history")
+    expect(PROTECTED_HOME_DOTFILES).toContain(".bash_history")
+    expect(PROTECTED_HOME_DOTFILES).toContain(".netrc")
+    expect(PROTECTED_HOME_DOTFILES).toContain(".git-credentials")
+    expect(PROTECTED_HOME_DOTFILES).toContain(".npmrc")
   })
 })
 
@@ -240,6 +251,13 @@ describe("collectIgnoredPaths", () => {
     expect(ignored).toContain(join(home, "Library", "Mail"))
     expect(ignored).toContain(join(home, "Library", "Safari"))
     expect(ignored).toContain(join(home, "Library", "Mobile Documents"))
+  })
+
+  it("includes protected home dotfiles", () => {
+    const ignored = collectIgnoredPaths(home, [workDir])
+    expect(ignored).toContain(join(home, ".zsh_history"))
+    expect(ignored).toContain(join(home, ".netrc"))
+    expect(ignored).toContain(join(home, ".git-credentials"))
   })
 
   it("matches simple patterns recursively in workdir subdirectories", () => {

--- a/src/profile.test.ts
+++ b/src/profile.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest"
 import { mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
-import { collectBlockedDirs, collectIgnoredPaths, generateProfile, isSelfProtected, parseHomeConfig, PROTECTED_DOTDIRS, PROTECTED_HOME_DOTFILES, PROTECTED_LIBRARY_DIRS } from "./profile.js"
+import { collectBlockedDirs, collectIgnoredPaths, collectReadOnlyDotfiles, generateProfile, isSelfProtected, parseHomeConfig, PROTECTED_DOTDIRS, PROTECTED_HOME_DOTFILES, PROTECTED_HOME_DOTFILES_RO, PROTECTED_LIBRARY_DIRS } from "./profile.js"
 
 describe("PROTECTED_DOTDIRS", () => {
   it("includes essential sensitive directories", () => {
@@ -10,6 +10,25 @@ describe("PROTECTED_DOTDIRS", () => {
     expect(PROTECTED_DOTDIRS).toContain(".gnupg")
     expect(PROTECTED_DOTDIRS).toContain(".docker")
     expect(PROTECTED_DOTDIRS).toContain(".cargo")
+  })
+
+  it("includes cloud credential directories", () => {
+    expect(PROTECTED_DOTDIRS).toContain(".aws")
+    expect(PROTECTED_DOTDIRS).toContain(".azure")
+    expect(PROTECTED_DOTDIRS).toContain(".azd")
+    expect(PROTECTED_DOTDIRS).toContain(".kube")
+    expect(PROTECTED_DOTDIRS).toContain(".config/gcloud")
+  })
+})
+
+describe("PROTECTED_HOME_DOTFILES_RO", () => {
+  it("includes shell init files", () => {
+    expect(PROTECTED_HOME_DOTFILES_RO).toContain(".zshrc")
+    expect(PROTECTED_HOME_DOTFILES_RO).toContain(".zprofile")
+    expect(PROTECTED_HOME_DOTFILES_RO).toContain(".zshenv")
+    expect(PROTECTED_HOME_DOTFILES_RO).toContain(".bashrc")
+    expect(PROTECTED_HOME_DOTFILES_RO).toContain(".bash_profile")
+    expect(PROTECTED_HOME_DOTFILES_RO).toContain(".profile")
   })
 })
 
@@ -260,6 +279,14 @@ describe("collectIgnoredPaths", () => {
     expect(ignored).toContain(join(home, ".git-credentials"))
   })
 
+  it("includes cloud credential directories", () => {
+    const ignored = collectIgnoredPaths(home, [workDir])
+    expect(ignored).toContain(join(home, ".aws"))
+    expect(ignored).toContain(join(home, ".azure"))
+    expect(ignored).toContain(join(home, ".kube"))
+    expect(ignored).toContain(join(home, ".config/gcloud"))
+  })
+
   it("matches simple patterns recursively in workdir subdirectories", () => {
     // .env exists at root and in a subdirectory
     writeFileSync(join(workDir, ".env"), "SECRET=1")
@@ -375,6 +402,16 @@ describe("collectIgnoredPaths", () => {
   })
 })
 
+describe("collectReadOnlyDotfiles", () => {
+  it("returns absolute paths for shell init files", () => {
+    const files = collectReadOnlyDotfiles("/Users/test")
+    expect(files).toContain("/Users/test/.zshrc")
+    expect(files).toContain("/Users/test/.bashrc")
+    expect(files).toContain("/Users/test/.profile")
+    expect(files).toContain("/Users/test/.config/fish/config.fish")
+  })
+})
+
 describe("generateProfile", () => {
   it("produces valid SBPL with version and allow default", () => {
     const profile = generateProfile(
@@ -444,5 +481,21 @@ describe("generateProfile", () => {
 
     expect(profile).not.toContain("deny file-write*")
     expect(profile).not.toContain("Read-only")
+  })
+
+  it("includes write-deny rules for read-only dotfiles", () => {
+    const profile = generateProfile(
+      ["/Users/test/work"],
+      [],
+      [],
+      [],
+      "",
+      ["/Users/test/.zshrc", "/Users/test/.bashrc"],
+    )
+
+    expect(profile).toContain('(literal "/Users/test/.zshrc")')
+    expect(profile).toContain('(literal "/Users/test/.bashrc")')
+    expect(profile).toContain("(deny file-write*")
+    expect(profile).toContain("write-protected against injection")
   })
 })

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -10,11 +10,16 @@ export const PROTECTED_DOTDIRS = [
   ".cargo",
   ".gradle",
   ".gem",
+  // Cloud provider credentials
+  ".aws",
+  ".azure",
+  ".azd",
+  ".kube",
+  ".config/gcloud",
 ]
 
 export const PROTECTED_HOME_DOTFILES = [
   ".zsh_history",
-  ".zsh_sessions",
   ".bash_history",
   ".sh_history",
   ".node_repl_history",
@@ -24,6 +29,20 @@ export const PROTECTED_HOME_DOTFILES = [
   ".npmrc",
   ".pypirc",
   ".extra",
+]
+
+// Shell init files: readable (tools/shells need them) but not writable (prevent injection)
+export const PROTECTED_HOME_DOTFILES_RO = [
+  ".zshrc",
+  ".zprofile",
+  ".zshenv",
+  ".zlogin",
+  ".zlogout",
+  ".bashrc",
+  ".bash_profile",
+  ".bash_login",
+  ".profile",
+  ".config/fish/config.fish",
 ]
 
 
@@ -248,6 +267,10 @@ function collectProtectedContainers(home: string): string[] {
   return matched
 }
 
+export function collectReadOnlyDotfiles(home: string): string[] {
+  return PROTECTED_HOME_DOTFILES_RO.map((f) => join(home, f))
+}
+
 export function collectIgnoredPaths(home: string, workDirs: string[]): string[] {
   const ignored: string[] = [
     ...PROTECTED_DOTDIRS.map((d) => join(home, d)),
@@ -333,6 +356,7 @@ export function generateProfile(
   ignoredPaths: string[],
   readOnlyDirs: string[] = [],
   home: string = "",
+  readOnlyFiles: string[] = [],
 ): string {
   const blockedRules = sbplDenyBlock(
     "Blocked paths (auto-generated from $HOME contents)",
@@ -352,6 +376,12 @@ export function generateProfile(
     readOnlyDirs.map(sbplSubpath),
   )
 
+  const readOnlyFileRules = sbplDenyBlock(
+    "Read-only home dotfiles (shell init - write-protected against injection)",
+    "file-write*",
+    readOnlyFiles.map(sbplLiteral),
+  )
+
   const systemRules = home
     ? sbplDenyBlock("System-level restrictions", "file*", collectSystemDenyPaths(home).map(sbplSubpath))
     : ""
@@ -361,6 +391,6 @@ export function generateProfile(
 
 (version 1)
 (allow default)
-${blockedRules}${ignoredRules}${readOnlyRules}${systemRules}
+${blockedRules}${ignoredRules}${readOnlyRules}${readOnlyFileRules}${systemRules}
 `
 }

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -2,7 +2,7 @@ import { existsSync, globSync, readFileSync, readdirSync, statSync } from "node:
 import { join, resolve } from "node:path"
 
 export const PROTECTED_DOTDIRS = [
-  // ".Trash",
+  ".Trash",
   ".ssh",
   ".gnupg",
   ".docker",
@@ -10,6 +10,20 @@ export const PROTECTED_DOTDIRS = [
   ".cargo",
   ".gradle",
   ".gem",
+]
+
+export const PROTECTED_HOME_DOTFILES = [
+  ".zsh_history",
+  ".zsh_sessions",
+  ".bash_history",
+  ".sh_history",
+  ".node_repl_history",
+  ".python_history",
+  ".netrc",
+  ".git-credentials",
+  ".npmrc",
+  ".pypirc",
+  ".extra",
 ]
 
 
@@ -237,6 +251,7 @@ function collectProtectedContainers(home: string): string[] {
 export function collectIgnoredPaths(home: string, workDirs: string[]): string[] {
   const ignored: string[] = [
     ...PROTECTED_DOTDIRS.map((d) => join(home, d)),
+    ...PROTECTED_HOME_DOTFILES.map((f) => join(home, f)),
     ...PROTECTED_LIBRARY_DIRS.map((d) => join(home, "Library", d)),
     ...new Set(collectProtectedContainers(home)),
   ]


### PR DESCRIPTION
## Summary

- Uncomment \`.Trash\` in \`PROTECTED_DOTDIRS\` so the Trash folder is always blocked
- Add new \`PROTECTED_HOME_DOTFILES\` list for sensitive files in \`\$HOME\`: shell histories (\`.zsh_history\`, \`.bash_history\`, etc.), credential files (\`.netrc\`, \`.git-credentials\`, \`.npmrc\`, \`.pypirc\`), and others
- Include protected dotfiles in \`collectIgnoredPaths\` deny rules

Dotdirs remain accessible (tools depend on them), but individual sensitive dotfiles are now blocked.

Closes #2

## Test plan

- [x] All 125 existing tests pass
- [x] New tests for \`PROTECTED_HOME_DOTFILES\` constant
- [x] New test that \`collectIgnoredPaths\` includes protected dotfiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)